### PR TITLE
Add connection timeout for TCP

### DIFF
--- a/escposprinter/src/main/java/com/dantsu/escposprinter/connection/tcp/TcpConnection.java
+++ b/escposprinter/src/main/java/com/dantsu/escposprinter/connection/tcp/TcpConnection.java
@@ -7,22 +7,40 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.Socket;
+import java.net.SocketTimeoutException;
 
 public class TcpConnection extends DeviceConnection {
     private Socket socket = null;
     private String address;
     private int port;
+    private int timeout = 0;
 
     /**
      * Create un instance of TcpConnection.
      *
      * @param address IP address of the device
      * @param port    Port of the device
+     * @param timeout Timeout in milliseconds to establish a connection
      */
     public TcpConnection(String address, int port) {
         super();
         this.address = address;
         this.port = port;
+    }
+
+    /**
+     * Create un instance of TcpConnection.
+     * Include timeout paramter in milliseconds
+     *
+     * @param address IP address of the device
+     * @param port    Port of the device
+     * @param timeout Timeout in milliseconds to establish a connection
+     */
+    public TcpConnection(String address, int port, int timeout) {
+        super();
+        this.address = address;
+        this.port = port;
+        this.timeout = timeout;
     }
 
     /**
@@ -43,13 +61,17 @@ public class TcpConnection extends DeviceConnection {
         }
         try {
             this.socket = new Socket();
-            this.socket.connect(new InetSocketAddress(InetAddress.getByName(this.address), this.port));
+            this.socket.connect(new InetSocketAddress(InetAddress.getByName(this.address), this.port), this.timeout); //https://docs.oracle.com/javase/6/docs/api/java/net/Socket.html#connect%28java.net.SocketAddress%29 - A timeout of zero is interpreted as an infinite timeou 
             this.outputStream = this.socket.getOutputStream();
             this.data = new byte[0];
         } catch (IOException e) {
             e.printStackTrace();
             this.disconnect();
             throw new EscPosConnectionException("Unable to connect to TCP device.");
+        } catch (SocketTimeoutException e) {
+            e.printStackTrace();
+            this.disconnect();
+            throw new EscPosConnectionException("Unable to connect to TCP device; exceeded timeout limit.");
         }
         return this;
     }

--- a/escposprinter/src/main/java/com/dantsu/escposprinter/connection/tcp/TcpConnection.java
+++ b/escposprinter/src/main/java/com/dantsu/escposprinter/connection/tcp/TcpConnection.java
@@ -20,7 +20,6 @@ public class TcpConnection extends DeviceConnection {
      *
      * @param address IP address of the device
      * @param port    Port of the device
-     * @param timeout Timeout in milliseconds to establish a connection
      */
     public TcpConnection(String address, int port) {
         super();
@@ -30,7 +29,9 @@ public class TcpConnection extends DeviceConnection {
 
     /**
      * Create un instance of TcpConnection.
-     * Include timeout paramter in milliseconds
+     * 
+     * Overload of the above function TcpConnection()
+     * Include timeout parameter in milliseconds.
      *
      * @param address IP address of the device
      * @param port    Port of the device
@@ -61,7 +62,7 @@ public class TcpConnection extends DeviceConnection {
         }
         try {
             this.socket = new Socket();
-            this.socket.connect(new InetSocketAddress(InetAddress.getByName(this.address), this.port), this.timeout); //https://docs.oracle.com/javase/6/docs/api/java/net/Socket.html#connect%28java.net.SocketAddress%29 - A timeout of zero is interpreted as an infinite timeou 
+            this.socket.connect(new InetSocketAddress(InetAddress.getByName(this.address), this.port), this.timeout); //https://docs.oracle.com/javase/8/docs/api/java/net/Socket.html#connect-java.net.SocketAddress-int- - A timeout of zero is interpreted as an infinite timeout 
             this.outputStream = this.socket.getOutputStream();
             this.data = new byte[0];
         } catch (IOException e) {


### PR DESCRIPTION
Attempting to connect to a TCP printer that is turned off or using the incorrect address will cause a period of wait time because java.net.Socket.Connect() has not been provided a timeout. 
Without a timeout, this function will attempt to connect for however long the OS chooses. It took about a minute or two to throw the exception

I have added an overload method for TcpConnection.TcpConnection() which takes a timeout as the third parameter. This timeout is passed to this.socket.connect() as a second parameter. The timeout is set to 0 by default.
https://docs.oracle.com/javase/8/docs/api/java/net/Socket.html#connect-java.net.SocketAddress-

Possibly linked to #104 .