### PR TITLE
Fix printer sub interface issue and find printers in USB_CLASS_MISC devices

### DIFF
--- a/escposprinter/src/main/java/com/dantsu/escposprinter/connection/usb/UsbDeviceHelper.java
+++ b/escposprinter/src/main/java/com/dantsu/escposprinter/connection/usb/UsbDeviceHelper.java
@@ -26,7 +26,7 @@ public class UsbDeviceHelper {
                 return usbInterface;
             }
         }
-        return usbDevice.getInterface(0);
+        return null;
     }
 
     /**

--- a/escposprinter/src/main/java/com/dantsu/escposprinter/connection/usb/UsbPrintersConnections.java
+++ b/escposprinter/src/main/java/com/dantsu/escposprinter/connection/usb/UsbPrintersConnections.java
@@ -55,7 +55,7 @@ public class UsbPrintersConnections extends UsbConnections {
         for (UsbConnection usbConnection : usbConnections) {
             UsbDevice device = usbConnection.getDevice();
             int usbClass = device.getDeviceClass();
-            if(usbClass == UsbConstants.USB_CLASS_PER_INTERFACE && UsbDeviceHelper.findPrinterInterface(device) != null) {
+            if((usbClass == UsbConstants.USB_CLASS_PER_INTERFACE || usbClass == UsbConstants.USB_CLASS_MISC ) && UsbDeviceHelper.findPrinterInterface(device) != null) {
                 usbClass = UsbConstants.USB_CLASS_PRINTER;
             }
             if (usbClass == UsbConstants.USB_CLASS_PRINTER) {


### PR DESCRIPTION
Returning the first interface of any USB_CLASS_PER_INTERFACE returns both my devices touch screen, and FTDI serial port. Any device with a per interface declaration would be considered a printer. The interface declares a return of null if no printer interface is found.

The Cashino CSN-A5L (VID 4070(0x0fe6), PID 33054(0x811e)) printer is an ESCPOS printer, declares itself a printer on an interface, but is USB_CLASS_MISC not USB_CLASS_PER_INTERFACE.
