### PR TITLE
Add support for bigger font sizes

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,6 +323,11 @@ Example :
 - `<font size='wide'>Some text</font>` : Double width of medium size
 - `<font size='tall'>Some text</font>` : Double height of medium size
 - `<font size='big'>Some text</font>` : Double width and height of medium size
+- `<font size='big-2'>Some text</font>` : 3 x width and height
+- `<font size='big-3'>Some text</font>` : 4 x width and height
+- `<font size='big-4'>Some text</font>` : 5 x width and height
+- `<font size='big-5'>Some text</font>` : 6 x width and height
+- `<font size='big-6'>Some text</font>` : 7 x width and height
 
 - `<font color='black'>Some text</font>` : black text - white background
 - `<font color='bg-black'>Some text</font>` : white text - black background

--- a/escposprinter/src/main/java/com/dantsu/escposprinter/EscPosPrinterCommands.java
+++ b/escposprinter/src/main/java/com/dantsu/escposprinter/EscPosPrinterCommands.java
@@ -44,6 +44,11 @@ public class EscPosPrinterCommands {
     public static final byte[] TEXT_SIZE_DOUBLE_HEIGHT = new byte[]{0x1D, 0x21, 0x01};
     public static final byte[] TEXT_SIZE_DOUBLE_WIDTH = new byte[]{0x1D, 0x21, 0x10};
     public static final byte[] TEXT_SIZE_BIG = new byte[]{0x1D, 0x21, 0x11};
+    public static final byte[] TEXT_SIZE_BIG_2 = new byte[]{0x1D, 0x21, 0x22};
+    public static final byte[] TEXT_SIZE_BIG_3 = new byte[]{0x1D, 0x21, 0x33};
+    public static final byte[] TEXT_SIZE_BIG_4 = new byte[]{0x1D, 0x21, 0x44};
+    public static final byte[] TEXT_SIZE_BIG_5 = new byte[]{0x1D, 0x21, 0x55};
+    public static final byte[] TEXT_SIZE_BIG_6 = new byte[]{0x1D, 0x21, 0x66};
 
     public static final byte[] TEXT_UNDERLINE_OFF = new byte[]{0x1B, 0x2D, 0x00};
     public static final byte[] TEXT_UNDERLINE_ON = new byte[]{0x1B, 0x2D, 0x01};

--- a/escposprinter/src/main/java/com/dantsu/escposprinter/textparser/PrinterTextParser.java
+++ b/escposprinter/src/main/java/com/dantsu/escposprinter/textparser/PrinterTextParser.java
@@ -43,6 +43,11 @@ public class PrinterTextParser {
 
     public static final String ATTR_FORMAT_TEXT_FONT_SIZE = "size";
     public static final String ATTR_FORMAT_TEXT_FONT_SIZE_BIG = "big";
+    public static final String ATTR_FORMAT_TEXT_FONT_SIZE_BIG_2 = "big-2";
+    public static final String ATTR_FORMAT_TEXT_FONT_SIZE_BIG_3 = "big-3";
+    public static final String ATTR_FORMAT_TEXT_FONT_SIZE_BIG_4 = "big-4";
+    public static final String ATTR_FORMAT_TEXT_FONT_SIZE_BIG_5 = "big-5";
+    public static final String ATTR_FORMAT_TEXT_FONT_SIZE_BIG_6 = "big-6";
     public static final String ATTR_FORMAT_TEXT_FONT_SIZE_TALL = "tall";
     public static final String ATTR_FORMAT_TEXT_FONT_SIZE_WIDE = "wide";
     public static final String ATTR_FORMAT_TEXT_FONT_SIZE_NORMAL = "normal";

--- a/escposprinter/src/main/java/com/dantsu/escposprinter/textparser/PrinterTextParserColumn.java
+++ b/escposprinter/src/main/java/com/dantsu/escposprinter/textparser/PrinterTextParserColumn.java
@@ -167,6 +167,21 @@ public class PrinterTextParserColumn {
                                         case PrinterTextParser.ATTR_FORMAT_TEXT_FONT_SIZE_BIG:
                                             textParser.addTextSize(EscPosPrinterCommands.TEXT_SIZE_BIG);
                                             break;
+                                        case PrinterTextParser.ATTR_FORMAT_TEXT_FONT_SIZE_BIG_2:
+                                            textParser.addTextSize(EscPosPrinterCommands.TEXT_SIZE_BIG_2);
+                                            break;
+                                        case PrinterTextParser.ATTR_FORMAT_TEXT_FONT_SIZE_BIG_3:
+                                            textParser.addTextSize(EscPosPrinterCommands.TEXT_SIZE_BIG_3);
+                                            break;
+                                        case PrinterTextParser.ATTR_FORMAT_TEXT_FONT_SIZE_BIG_4:
+                                            textParser.addTextSize(EscPosPrinterCommands.TEXT_SIZE_BIG_4);
+                                            break;
+                                        case PrinterTextParser.ATTR_FORMAT_TEXT_FONT_SIZE_BIG_5:
+                                            textParser.addTextSize(EscPosPrinterCommands.TEXT_SIZE_BIG_5);
+                                            break;
+                                        case PrinterTextParser.ATTR_FORMAT_TEXT_FONT_SIZE_BIG_6:
+                                            textParser.addTextSize(EscPosPrinterCommands.TEXT_SIZE_BIG_6);
+                                            break;
                                     }
                                 } else {
                                     textParser.addTextSize(textParser.getLastTextSize());

--- a/escposprinter/src/main/java/com/dantsu/escposprinter/textparser/PrinterTextParserString.java
+++ b/escposprinter/src/main/java/com/dantsu/escposprinter/textparser/PrinterTextParserString.java
@@ -33,7 +33,19 @@ public class PrinterTextParserString implements IPrinterTextParserElement {
     public int length() throws EscPosEncodingException {
         EscPosCharsetEncoding charsetEncoding = this.printer.getEncoding();
 
-        int coef = Arrays.equals(this.textSize, EscPosPrinterCommands.TEXT_SIZE_DOUBLE_WIDTH) || Arrays.equals(this.textSize, EscPosPrinterCommands.TEXT_SIZE_BIG) ? 2 : 1;
+        int coef = 1;
+        if(Arrays.equals(this.textSize, EscPosPrinterCommands.TEXT_SIZE_DOUBLE_WIDTH) || Arrays.equals(this.textSize, EscPosPrinterCommands.TEXT_SIZE_BIG))
+            coef = 2;
+        else if(Arrays.equals(this.textSize, EscPosPrinterCommands.TEXT_SIZE_BIG_2))
+            coef = 3;
+        else if(Arrays.equals(this.textSize, EscPosPrinterCommands.TEXT_SIZE_BIG_3))
+            coef = 4;
+        else if(Arrays.equals(this.textSize, EscPosPrinterCommands.TEXT_SIZE_BIG_4))
+            coef = 5;
+        else if(Arrays.equals(this.textSize, EscPosPrinterCommands.TEXT_SIZE_BIG_5))
+            coef = 6;
+        else if(Arrays.equals(this.textSize, EscPosPrinterCommands.TEXT_SIZE_BIG_6))
+            coef = 7;
 
         if (charsetEncoding != null) {
             try {


### PR DESCRIPTION
Can we add support for bigger fonts?
Someone has been asking for it here also: https://github.com/DantSu/ESCPOS-ThermalPrinter-Android/issues/226

Here's the Programmer's guide for the NCR7199 printer on which this has been tested to work (though the 8 times magnification - 0x77 - didn't seem to work as expected and has therefor been left out).

This specific command (or rather parameter) is described on page 72 (or 2-52 depending on how you interpret page numbers).

[7199 Programmer's Guide.pdf](https://github.com/DantSu/ESCPOS-ThermalPrinter-Android/files/8765131/7199.Programmer.s.Guide.pdf)
