### PR TITLE
Use list of 'override' printers to return even if interface class is not USB_CLASS_PRINTER.

### DIFF
--- a/escposprinter/src/main/java/com/dantsu/escposprinter/connection/usb/UsbDeviceHelper.java
+++ b/escposprinter/src/main/java/com/dantsu/escposprinter/connection/usb/UsbDeviceHelper.java
@@ -7,6 +7,8 @@ import android.hardware.usb.UsbInterface;
 
 import androidx.annotation.Nullable;
 
+import java.util.Arrays;
+
 public class UsbDeviceHelper {
     /**
      * Find the correct USB interface for printing
@@ -26,7 +28,7 @@ public class UsbDeviceHelper {
                 return usbInterface;
             }
         }
-        return null;
+        return isOverridePrinter(usbDevice) ? usbDevice.getInterface(0) : null;
     }
 
     /**
@@ -47,5 +49,17 @@ public class UsbDeviceHelper {
             }
         }
         return null;
+    }
+
+    final static int VENDOR_EPSON = 1208;
+    final static int PRODUCT_EPSON_TM_20 = 514;
+
+    static boolean isOverridePrinter(UsbDevice usbDevice) {
+        switch (usbDevice.getVendorId()) {
+            case VENDOR_EPSON:
+                return Arrays.asList(PRODUCT_EPSON_TM_20).contains(usbDevice.getProductId());
+            default:
+                return false;
+        }
     }
 }


### PR DESCRIPTION
Suggestion to work around printers that are not coded with a `USB_CLASS_PRINTER` interface.

Originally if no interface with `USB_CLASS_PRINTER` was found, the first interface was returned by default. If there were other devices on the USB bus of class `USB_CLASS_PER_INTERFACE` or `USB_CLASS_MISC` that were enumerated first, those devices would be returned instead of the printer.

This code adds a check for printers currently known to no be coded `USB_CLASS_PRINTER`, and will default to the first interface for those, instead or returning `null`.

suggested fix DantSu/ESCPOS-ThermalPrinter-Android#331