### PR TITLE
Add option to select bitmap algorithm

### DIFF
--- a/escposprinter/src/main/java/com/dantsu/escposprinter/EscPosPrinter.java
+++ b/escposprinter/src/main/java/com/dantsu/escposprinter/EscPosPrinter.java
@@ -34,6 +34,20 @@ public class EscPosPrinter extends EscPosPrinterSize {
      * @param printerDpi                  DPI of the connected printer
      * @param printerWidthMM              Printing width in millimeters
      * @param printerNbrCharactersPerLine The maximum number of characters that can be printed on a line.
+     * @param bitmapMode                  Mode for bitmap printing. Can be gradient or sharp.
+     */
+    public EscPosPrinter(DeviceConnection printerConnection, int printerDpi, float printerWidthMM, int printerNbrCharactersPerLine, int bitmapMode) throws EscPosConnectionException {
+        this(printerConnection != null ? new EscPosPrinterCommands(printerConnection) : null, printerDpi, printerWidthMM, printerNbrCharactersPerLine);
+        this.bitmapMode = bitmapMode;
+    }
+
+    /**
+     * Create new instance of EscPosPrinter.
+     *
+     * @param printerConnection           Instance of class which implement DeviceConnection
+     * @param printerDpi                  DPI of the connected printer
+     * @param printerWidthMM              Printing width in millimeters
+     * @param printerNbrCharactersPerLine The maximum number of characters that can be printed on a line.
      * @param charsetEncoding             Set the charset encoding.
      */
     public EscPosPrinter(DeviceConnection printerConnection, int printerDpi, float printerWidthMM, int printerNbrCharactersPerLine, EscPosCharsetEncoding charsetEncoding) throws EscPosConnectionException {

--- a/escposprinter/src/main/java/com/dantsu/escposprinter/EscPosPrinterCommands.java
+++ b/escposprinter/src/main/java/com/dantsu/escposprinter/EscPosPrinterCommands.java
@@ -103,12 +103,12 @@ public class EscPosPrinterCommands {
     }
 
     /**
-     * Convert Bitmap instance to a byte array compatible with ESC/POS printer.
+     * Convert Bitmap instance to a byte array compatible with ESC/POS printer using gradient mode
      *
      * @param bitmap Bitmap to be convert
      * @return Bytes contain the image in ESC/POS command
      */
-    public static byte[] bitmapToBytes(Bitmap bitmap) {
+    public static byte[] bitmapToBytesGradient(Bitmap bitmap) {
         int
             bitmapWidth = bitmap.getWidth(),
             bitmapHeight = bitmap.getHeight(),
@@ -152,6 +152,48 @@ public class EscPosPrinterCommands {
             greyscaleCoefficientInit += 2;
             if (greyscaleCoefficientInit > 15) {
                 greyscaleCoefficientInit = 0;
+            }
+        }
+
+        return imageBytes;
+    }
+
+    /**
+     * Convert Bitmap instance to a byte array compatible with ESC/POS printer using sharp mode
+     *
+     * @param bitmap Bitmap to be convert
+     * @return Bytes contain the image in ESC/POS command
+     */
+    public static byte[] bitmapToBytesSharp(Bitmap bitmap) {
+        int
+            bitmapWidth = bitmap.getWidth(),
+            bitmapHeight = bitmap.getHeight(),
+            bytesByLine = (int) Math.ceil(((float) bitmapWidth) / 8f);
+
+        byte[] imageBytes = EscPosPrinterCommands.initGSv0Command(bytesByLine, bitmapHeight);
+
+        int i = 8;
+        for (int posY = 0; posY < bitmapHeight; posY++) {
+            for (int j = 0; j < bitmapWidth; j += 8) {
+                StringBuilder stringBinary = new StringBuilder();
+                for (int k = 0; k < 8; k++) {
+                    int posX = j + k;
+                    if (posX < bitmapWidth) {
+                        int color = bitmap.getPixel(posX, posY),
+                                r = (color >> 16) & 0xff,
+                                g = (color >> 8) & 0xff,
+                                b = color & 0xff;
+
+                        if (r > 160 && g > 160 && b > 160) {
+                            stringBinary.append("0");
+                        } else {
+                            stringBinary.append("1");
+                        }
+                    } else {
+                        stringBinary.append("0");
+                    }
+                }
+                imageBytes[i++] = (byte) Integer.parseInt(stringBinary.toString(), 2);
             }
         }
 

--- a/escposprinter/src/main/java/com/dantsu/escposprinter/EscPosPrinterSize.java
+++ b/escposprinter/src/main/java/com/dantsu/escposprinter/EscPosPrinterSize.java
@@ -4,8 +4,13 @@ package com.dantsu.escposprinter;
 import android.graphics.Bitmap;
 
 public abstract class EscPosPrinterSize {
+    protected int bitmapMode = BITMAP_GRADIENT_MODE;
 
     public static final float INCH_TO_MM = 25.4f;
+
+    public static final int BITMAP_GRADIENT_MODE = 0;
+
+    public static final int BITMAP_SHARP_MODE = 1;
 
     protected int printerDpi;
     protected float printerWidthMM;
@@ -67,6 +72,8 @@ public abstract class EscPosPrinterSize {
         return this.printerCharSizeWidthPx;
     }
 
+    public int getBitmapMode() { return bitmapMode; }
+
     /**
      * Convert from millimeters to dot the mmSize variable.
      *
@@ -106,6 +113,10 @@ public abstract class EscPosPrinterSize {
             bitmap = Bitmap.createScaledBitmap(bitmap, bitmapWidth, bitmapHeight, true);
         }
 
-        return EscPosPrinterCommands.bitmapToBytes(bitmap);
+        if (this.bitmapMode == BITMAP_GRADIENT_MODE) {
+            return EscPosPrinterCommands.bitmapToBytesGradient(bitmap);
+        } else {
+            return EscPosPrinterCommands.bitmapToBytesSharp(bitmap);
+        }
     }
 }


### PR DESCRIPTION
Fixes #374 by adding a constructor parameter to select which algorithm to be used for converting Bitmap to bytes. 

Options are `BITMAP_GRADIENT_MODE` (post 3.1.2) or `BITMAP_SHARP_MODE` (pre 3.1.2)