### PR TITLE
Fix pauses while printing

### DIFF
--- a/escposprinter/src/main/java/com/dantsu/escposprinter/EscPosPrinter.java
+++ b/escposprinter/src/main/java/com/dantsu/escposprinter/EscPosPrinter.java
@@ -118,6 +118,7 @@ public class EscPosPrinter extends EscPosPrinterSize {
                 .parse();
 
         this.printer.reset();
+        this.printer.setCharsetEncoding();
 
         for (PrinterTextParserLine line : linesParsed) {
             PrinterTextParserColumn[] columns = line.getColumns();

--- a/escposprinter/src/main/java/com/dantsu/escposprinter/EscPosPrinterCommands.java
+++ b/escposprinter/src/main/java/com/dantsu/escposprinter/EscPosPrinterCommands.java
@@ -465,7 +465,7 @@ public class EscPosPrinterCommands {
 
         try {
             byte[] textBytes = text.getBytes(this.charsetEncoding.getName());
-            this.printerConnection.write(this.charsetEncoding.getCommand());
+            //this.printerConnection.write(this.charsetEncoding.getCommand());
             //this.printerConnection.write(EscPosPrinterCommands.TEXT_FONT_A);
 
 
@@ -506,6 +506,11 @@ public class EscPosPrinterCommands {
             throw new EscPosEncodingException(e.getMessage());
         }
 
+        return this;
+    }
+
+    public EscPosPrinterCommands setCharsetEncoding() {
+        this.printerConnection.write(this.charsetEncoding.getCommand());
         return this;
     }
 
@@ -590,7 +595,7 @@ public class EscPosPrinterCommands {
 
         for (byte[] bytes : bytesToPrint) {
             this.printerConnection.write(bytes);
-            this.printerConnection.send();
+            //this.printerConnection.send();
         }
 
         return this;
@@ -694,7 +699,7 @@ public class EscPosPrinterCommands {
         }
 
         this.printerConnection.write(new byte[]{EscPosPrinterCommands.LF});
-        this.printerConnection.send();
+        //this.printerConnection.send();
 
         if (align != null) {
             this.printerConnection.write(align);
@@ -714,9 +719,9 @@ public class EscPosPrinterCommands {
         }
 
         if (dots > 0) {
-            this.printerConnection.write(new byte[]{0x1B, 0x4A, (byte) dots});
-            this.printerConnection.send(dots);
+            this.printerConnection.write(new byte[]{0x1B, 0x4A, (byte) dots}); 
         }
+        this.printerConnection.send(dots);
 
         return this;
     }


### PR DESCRIPTION
Fixes #399 

@DantSu After some digging, we found that the issue was that data was sent in small chunks to the printer because the send() command is called every newline. Moreover, every time a text line is printed, the charset is being set (which only needs to be set when printing start). Therefore; we did two things:

1. We created a separate function to set the charset and call this right after reset() in the printFormattedText() function
2. We removed the send() command in printImage and printNewLine, and made sure the send() command is always called in feedPaper() (even if the number of lines is 0)

The steps above solved the issue.

What we were wondering: is there any logic in calling the send() command in some places, but not all of them (we figured you might call it in printImage() because a lot of data needs to be sent, but this is not the case for printNewLine()). Is there any maximum on the buffer before it needs to be sent?

Many thanks!