### PR TITLE
Add small font size for text lines.

### DIFF
--- a/app/src/main/java/com/dantsu/thermalprinter/MainActivity.java
+++ b/app/src/main/java/com/dantsu/thermalprinter/MainActivity.java
@@ -299,7 +299,10 @@ public class MainActivity extends AppCompatActivity {
                 "\n" +
                 "[C]<barcode type='ean13' height='10'>831254784551</barcode>\n" +
                 "[L]\n" +
-                "[C]<qrcode size='20'>https://dantsu.com/</qrcode>\n"
+                "[C]<qrcode size='20'>https://dantsu.com/</qrcode>\n" +
+                "[L]\n" +
+                "[C]<font size='normal'>1234567890123456789012345678901234567890123456789012345678901234567890</font>\n" +
+                "[C]<font size='small'>1234567890123456789012345678901234567890123456789012345678901234567890</font>\n"
         );
     }
 }

--- a/escposprinter/src/main/java/com/dantsu/escposprinter/EscPosPrinterCommands.java
+++ b/escposprinter/src/main/java/com/dantsu/escposprinter/EscPosPrinterCommands.java
@@ -40,6 +40,7 @@ public class EscPosPrinterCommands {
     public static final byte[] TEXT_FONT_D = new byte[]{0x1B, 0x4D, 0x03};
     public static final byte[] TEXT_FONT_E = new byte[]{0x1B, 0x4D, 0x04};
 
+    public static final byte[] TEXT_SIZE_SMALL = new byte[]{0x1B, 0x21, 0x01};
     public static final byte[] TEXT_SIZE_NORMAL = new byte[]{0x1D, 0x21, 0x00};
     public static final byte[] TEXT_SIZE_DOUBLE_HEIGHT = new byte[]{0x1D, 0x21, 0x01};
     public static final byte[] TEXT_SIZE_DOUBLE_WIDTH = new byte[]{0x1D, 0x21, 0x10};

--- a/escposprinter/src/main/java/com/dantsu/escposprinter/textparser/PrinterTextParser.java
+++ b/escposprinter/src/main/java/com/dantsu/escposprinter/textparser/PrinterTextParser.java
@@ -51,6 +51,7 @@ public class PrinterTextParser {
     public static final String ATTR_FORMAT_TEXT_FONT_SIZE_TALL = "tall";
     public static final String ATTR_FORMAT_TEXT_FONT_SIZE_WIDE = "wide";
     public static final String ATTR_FORMAT_TEXT_FONT_SIZE_NORMAL = "normal";
+    public static final String ATTR_FORMAT_TEXT_FONT_SIZE_SMALL = "small";
 
     public static final String ATTR_FORMAT_TEXT_FONT_COLOR = "color";
     public static final String ATTR_FORMAT_TEXT_FONT_COLOR_BLACK = "black";

--- a/escposprinter/src/main/java/com/dantsu/escposprinter/textparser/PrinterTextParserColumn.java
+++ b/escposprinter/src/main/java/com/dantsu/escposprinter/textparser/PrinterTextParserColumn.java
@@ -158,6 +158,9 @@ public class PrinterTextParserColumn {
                                         default:
                                             textParser.addTextSize(EscPosPrinterCommands.TEXT_SIZE_NORMAL);
                                             break;
+                                        case PrinterTextParser.ATTR_FORMAT_TEXT_FONT_SIZE_SMALL:
+                                            textParser.addTextSize(EscPosPrinterCommands.TEXT_SIZE_SMALL);
+                                            break;
                                         case PrinterTextParser.ATTR_FORMAT_TEXT_FONT_SIZE_TALL:
                                             textParser.addTextSize(EscPosPrinterCommands.TEXT_SIZE_DOUBLE_HEIGHT);
                                             break;


### PR DESCRIPTION
Add small font size for text lines.
Tested on Control iD printer.

![printer](https://github.com/DantSu/ESCPOS-ThermalPrinter-Android/assets/8862909/927d3d46-8b05-46db-9dc7-a0802102b02a)
![receipt](https://github.com/DantSu/ESCPOS-ThermalPrinter-Android/assets/8862909/d8fe7f05-9b5b-476e-a54d-62179667ec8f)
