### PR TITLE
Implement Code39

### DIFF
--- a/escposprinter/src/main/java/com/dantsu/escposprinter/EscPosPrinterCommands.java
+++ b/escposprinter/src/main/java/com/dantsu/escposprinter/EscPosPrinterCommands.java
@@ -68,6 +68,7 @@ public class EscPosPrinterCommands {
     public static final int BARCODE_TYPE_UPCE = 66;
     public static final int BARCODE_TYPE_EAN13 = 67;
     public static final int BARCODE_TYPE_EAN8 = 68;
+    public static final int BARCODE_TYPE_39 = 69;
     public static final int BARCODE_TYPE_ITF = 70;
     public static final int BARCODE_TYPE_128 = 73;
 

--- a/escposprinter/src/main/java/com/dantsu/escposprinter/barcode/Barcode39.java
+++ b/escposprinter/src/main/java/com/dantsu/escposprinter/barcode/Barcode39.java
@@ -1,0 +1,21 @@
+package com.dantsu.escposprinter.barcode;
+
+import com.dantsu.escposprinter.EscPosPrinterSize;
+import com.dantsu.escposprinter.EscPosPrinterCommands;
+import com.dantsu.escposprinter.exceptions.EscPosBarcodeException;
+
+public class Barcode39 extends Barcode {
+    public Barcode39(EscPosPrinterSize printerSize, String code, float widthMM, float heightMM, int textPosition) throws EscPosBarcodeException {
+        super(printerSize, EscPosPrinterCommands.BARCODE_TYPE_39, code, widthMM, heightMM, textPosition);
+    }
+
+    @Override
+    public int getCodeLength() {
+        return this.code.length();
+    }
+
+    @Override
+    public int getColsCount() {
+        return (this.getCodeLength() + 4) * 16;
+    }
+}

--- a/escposprinter/src/main/java/com/dantsu/escposprinter/textparser/PrinterTextParser.java
+++ b/escposprinter/src/main/java/com/dantsu/escposprinter/textparser/PrinterTextParser.java
@@ -27,6 +27,7 @@ public class PrinterTextParser {
     public static final String ATTR_BARCODE_TYPE_UPCA = "upca";
     public static final String ATTR_BARCODE_TYPE_UPCE = "upce";
     public static final String ATTR_BARCODE_TYPE_128 = "128";
+    public static final String ATTR_BARCODE_TYPE_39 = "39";
     public static final String ATTR_BARCODE_TEXT_POSITION = "text";
     public static final String ATTR_BARCODE_TEXT_POSITION_NONE = "none";
     public static final String ATTR_BARCODE_TEXT_POSITION_ABOVE = "above";

--- a/escposprinter/src/main/java/com/dantsu/escposprinter/textparser/PrinterTextParserBarcode.java
+++ b/escposprinter/src/main/java/com/dantsu/escposprinter/textparser/PrinterTextParserBarcode.java
@@ -6,6 +6,7 @@ import com.dantsu.escposprinter.EscPosPrinter;
 import com.dantsu.escposprinter.EscPosPrinterCommands;
 import com.dantsu.escposprinter.barcode.Barcode;
 import com.dantsu.escposprinter.barcode.Barcode128;
+import com.dantsu.escposprinter.barcode.Barcode39;
 import com.dantsu.escposprinter.barcode.BarcodeEAN13;
 import com.dantsu.escposprinter.barcode.BarcodeEAN8;
 import com.dantsu.escposprinter.barcode.BarcodeUPCA;
@@ -113,6 +114,9 @@ public class PrinterTextParserBarcode implements IPrinterTextParserElement {
                 break;
             case PrinterTextParser.ATTR_BARCODE_TYPE_128:
                 this.barcode = new Barcode128(printer, code, width, height, textPosition);
+                break;
+            case PrinterTextParser.ATTR_BARCODE_TYPE_39:
+                this.barcode = new Barcode39(printer, code, width, height, textPosition);
                 break;
             default:
                 throw new EscPosParserException("Invalid barcode attribute : " + PrinterTextParser.ATTR_BARCODE_TYPE);


### PR DESCRIPTION
As per subject.

Results has been checked with the Barcode Scanner app by ZXing

Test printer (Goojprt PT-210, an MPT-II clone) is compatible with ESC/POS and a wide set of barcodes, including Code128 and Code39, and works correctly with a printing app [known to use your lib in the credits](https://play.google.com/store/apps/details?id=mate.bluetoothprint&hl=en)

I've roughly calculated a column width of (data+4)*16 in case of wide encoding: 

Command value has been taken from [here](https://reference.epson-biz.com/modules/ref_escpos/index.php?content_id=128)

For some reason, tho, it adds a R character at the end of the encoded data (possibly its Module43 checksum)

Here's the barcode in Code128
![20231022_232901](https://github.com/DantSu/ESCPOS-ThermalPrinter-Android/assets/7688273/1b48c471-7863-4fc4-8182-a274312e41e7)

Here's the same one in Code39 made with your example code and my mod
![20231022_232906](https://github.com/DantSu/ESCPOS-ThermalPrinter-Android/assets/7688273/109fb281-7100-4fa7-8edc-0f397e5a8b87)

Again Code39, from the aforementioned app using your lib
![20231022_234926](https://github.com/DantSu/ESCPOS-ThermalPrinter-Android/assets/7688273/3f488118-8fe7-4186-8654-63dee702f114)
