### PR TITLE
Detect "uncategorized" Bluetooth printers

### DIFF
--- a/escposprinter/src/main/java/com/dantsu/escposprinter/connection/bluetooth/BluetoothPrintersConnections.java
+++ b/escposprinter/src/main/java/com/dantsu/escposprinter/connection/bluetooth/BluetoothPrintersConnections.java
@@ -54,8 +54,9 @@ public class BluetoothPrintersConnections extends BluetoothConnections {
             int majDeviceCl = device.getBluetoothClass().getMajorDeviceClass(),
                     deviceCl = device.getBluetoothClass().getDeviceClass();
 
-            if (majDeviceCl == BluetoothClass.Device.Major.IMAGING && (deviceCl == 1664 || deviceCl == BluetoothClass.Device.Major.IMAGING)) {
-                printersTmp[i++] = new BluetoothConnection(device);
+            if ((majDeviceCl == BluetoothClass.Device.Major.IMAGING && (deviceCl == 1664 || deviceCl == BluetoothClass.Device.Major.IMAGING ))
+               || (deviceCl == BluetoothClass.Device.Major.UNCATEGORIZED)) {    
+                    printersTmp[i++] = new BluetoothConnection(device);
             }
         }
         BluetoothConnection[] bluetoothPrinters = new BluetoothConnection[i];


### PR DESCRIPTION
Hi @DantSu, with this change app detects Bluetooth printers whose device class is "BluetoothClass.Device.Major.UNCATEGORIZED" (7936), some Bluetooth printers (Like GOOJPRT PT-210) uses this class.