### PR TITLE
Add partial cut partial cut (fix cut in wrong place)

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,6 +487,11 @@ Print a formatted text, feed paper (20 millimeters) and cut the paper. Read the 
 - **param** `String text` : Formatted text to be printed.
 - **return** `Printer` : Fluent interface
 
+#### Method : `printFormattedTextAndPartialCut(String text)`
+Print a formatted text, feed paper (20 millimeters) and partial cut the paper. Read the ["Formatted Text : Syntax guide" section](#formatted-text--syntax-guide) for more information about text formatting options.
+- **param** `String text` : Formatted text to be printed.
+- **return** `Printer` : Fluent interface
+
 #### Method : `printFormattedText(String text, float mmFeedPaper)`
 Print a formatted text and feed paper (`mmFeedPaper` millimeters). Read the ["Formatted Text : Syntax guide" section](#formatted-text--syntax-guide) for more information about text formatting options.
 - **param** `String text` : Formatted text to be printed.
@@ -495,6 +500,12 @@ Print a formatted text and feed paper (`mmFeedPaper` millimeters). Read the ["Fo
 
 #### Method : `printFormattedTextAndCut(String text, float mmFeedPaper)`
 Print a formatted text, feed paper (`mmFeedPaper` millimeters) and cut the paper. Read the ["Formatted Text : Syntax guide" section](#formatted-text--syntax-guide) for more information about text formatting options.
+- **param** `String text` : Formatted text to be printed.
+- **param** `float mmFeedPaper` : Millimeter distance feed paper at the end.
+- **return** `Printer` : Fluent interface
+
+#### Method : `printFormattedTextAndPartialCut(String text, float mmFeedPaper)`
+Print a formatted text, feed paper (`mmFeedPaper` millimeters) and partial cut the paper. Read the ["Formatted Text : Syntax guide" section](#formatted-text--syntax-guide) for more information about text formatting options.
 - **param** `String text` : Formatted text to be printed.
 - **param** `float mmFeedPaper` : Millimeter distance feed paper at the end.
 - **return** `Printer` : Fluent interface
@@ -513,6 +524,12 @@ Print a formatted text and feed paper (`dotsFeedPaper` dots). Read the ["Formatt
 
 #### Method : `printFormattedTextAndCut(String text, int dotsFeedPaper)`
 Print a formatted text, feed paper (`dotsFeedPaper` dots) and cut the paper. Read the ["Formatted Text : Syntax guide" section](#formatted-text--syntax-guide) for more information about text formatting options.
+- **param** `String text` : Formatted text to be printed.
+- **param** `int dotsFeedPaper` : Distance feed paper at the end.
+- **return** `Printer` : Fluent interface
+
+#### Method : `printFormattedTextAndPartialCut(String text, int dotsFeedPaper)`
+Print a formatted text, feed paper (`dotsFeedPaper` dots) and partial cut the paper. Read the ["Formatted Text : Syntax guide" section](#formatted-text--syntax-guide) for more information about text formatting options.
 - **param** `String text` : Formatted text to be printed.
 - **param** `int dotsFeedPaper` : Distance feed paper at the end.
 - **return** `Printer` : Fluent interface

--- a/escposprinter/src/main/java/com/dantsu/escposprinter/EscPosPrinter.java
+++ b/escposprinter/src/main/java/com/dantsu/escposprinter/EscPosPrinter.java
@@ -151,6 +151,16 @@ public class EscPosPrinter extends EscPosPrinterSize {
     }
 
     /**
+     * Print a formatted text and partial cut the paper. Read the README.md for more information about text formatting options.
+     *
+     * @param text Formatted text to be printed.
+     * @return Fluent interface
+     */
+    public EscPosPrinter printFormattedTextAndPartialCut(String text) throws EscPosConnectionException, EscPosParserException, EscPosEncodingException, EscPosBarcodeException {
+        return this.printFormattedTextAndCut(text, 20f);
+    }
+
+    /**
      * Print a formatted text and cut the paper. Read the README.md for more information about text formatting options.
      *
      * @param text        Formatted text to be printed.
@@ -159,6 +169,17 @@ public class EscPosPrinter extends EscPosPrinterSize {
      */
     public EscPosPrinter printFormattedTextAndCut(String text, float mmFeedPaper) throws EscPosConnectionException, EscPosParserException, EscPosEncodingException, EscPosBarcodeException {
         return this.printFormattedTextAndCut(text, this.mmToPx(mmFeedPaper));
+    }
+
+    /**
+     * Print a formatted text and partial cut the paper. Read the README.md for more information about text formatting options.
+     *
+     * @param text        Formatted text to be printed.
+     * @param mmFeedPaper millimeter distance feed paper at the end.
+     * @return Fluent interface
+     */
+    public EscPosPrinter printFormattedTextAndPartialCut(String text, float mmFeedPaper) throws EscPosConnectionException, EscPosParserException, EscPosEncodingException, EscPosBarcodeException {
+        return this.printFormattedTextAndPartialCut(text, this.mmToPx(mmFeedPaper));
     }
 
     /**
@@ -175,6 +196,24 @@ public class EscPosPrinter extends EscPosPrinterSize {
 
         this.printFormattedText(text, dotsFeedPaper);
         this.printer.cutPaper();
+
+        return this;
+    }
+
+    /**
+     * Print a formatted text and partial cut the paper. Read the README.md for more information about text formatting options.
+     *
+     * @param text          Formatted text to be printed.
+     * @param dotsFeedPaper distance feed paper at the end.
+     * @return Fluent interface
+     */
+    public EscPosPrinter printFormattedTextAndPartialCut(String text, int dotsFeedPaper) throws EscPosConnectionException, EscPosParserException, EscPosEncodingException, EscPosBarcodeException {
+        if (this.printer == null || this.printerNbrCharactersPerLine == 0) {
+            return this;
+        }
+
+        this.printFormattedText(text, dotsFeedPaper);
+        this.printer.partialCutPaper();
 
         return this;
     }

--- a/escposprinter/src/main/java/com/dantsu/escposprinter/EscPosPrinterCommands.java
+++ b/escposprinter/src/main/java/com/dantsu/escposprinter/EscPosPrinterCommands.java
@@ -738,6 +738,21 @@ public class EscPosPrinterCommands {
     }
 
     /**
+     * Partial cut the paper
+     *
+     * @return Fluent interface
+     */
+    public EscPosPrinterCommands partialCutPaper() throws EscPosConnectionException {
+        if (!this.printerConnection.isConnected()) {
+            return this;
+        }
+
+        this.printerConnection.write(new byte[]{0x1D, 0x56, 66, 0x00});
+        this.printerConnection.send(100);
+        return this;
+    }
+
+    /**
      * Open the cash box
      *
      * @return Fluent interface


### PR DESCRIPTION
When printing on a generic brand printer, the cut was being made within the printing area. By using partial cut it was possible to solve this problem.